### PR TITLE
Rtpengine interface IP family change handling

### DIFF
--- a/kamailio/users/config/kamailio.cfg
+++ b/kamailio/users/config/kamailio.cfg
@@ -3009,20 +3009,39 @@ route[RTPENGINE_INTERFACES] {
 
     # Direction must be set only in first SDP (initial INVITE with SDP or first response with SDP to initial INVITE with no SDP)
     if ($var(is_from_inside)) {
+        $var(direction_from) = $var(usersAddress);
         if ($dlg_var(externalSocket) != $null) {
             # first response with SDP from AS to initial INVITE with no SDP from UAC
-            $var(interfaces) = "direction=" + $var(usersAddress) + " direction=" + $dlg_var(externalSocket);
+            $var(direction_to) = $dlg_var(externalSocket);
         } else if ($fs != $null) {
             # initial INVITE from AS with SDP
-            $var(branchsockaddr) = $(fs{s.select,1,:});
-            $var(interfaces) = "direction=" + $var(usersAddress) + " direction=" + $var(branchsockaddr);
+            $var(direction_to) = $(fs{s.select,1,:});
         } else {
             xwarn("[$dlg_var(cidhash)] RTPENGINE-INTERFACES: No dlg_var(externalSocket) and fs, this is weird, check!\n");
-            $var(interfaces) = "direction=" + $var(usersAddress) + " direction=" + $var(usersAddress);
+            $var(direction_to) = $var(usersAddress);
         }
     } else {
-        $var(interfaces) = "direction=" + $Ri + " direction=" + $var(usersAddress);
+        $var(direction_from) = $Ri;
+        $var(direction_to) = $var(usersAddress);
     }
+    ip_type($var(direction_from));
+    $var(direction_from_iptype) = $rc;
+    ip_type($var(direction_to));
+    $var(direction_to_iptype) = $rc;
+    # Direction's IP families are different so set rtpengine correct IP interface according to direction_to_iptype
+    $var(direction_address_family) = "";
+    if( $var(direction_from_iptype) != $var(direction_to_iptype)){
+        switch($var(direction_to_iptype)){
+            case 1:
+                $var(direction_address_family) = "address-family=IP4";
+                break;
+            case 2:
+            case 3:
+                $var(direction_address_family) = "address-family=IP6";
+                break;
+        }
+    }
+    $var(interfaces) = "direction=" + $var(direction_from) + " direction=" + $var(direction_to) + " " + $var(direction_address_family);
 }
 
 route[RTPENGINE_UNKNOWN_BYE] {


### PR DESCRIPTION
<!--
  - All pull requests must be done against bleeding branch.
  - All provided code must be GPLv3 license compatible.
-->

#### Type Of Change <!-- Mark one with X -->
- [x] Small bug fix
- [ ] New feature or enhancement
- [ ] Breaking change

#### Checklist:
- [x] Commits are named and have tag following [commit rules](https://github.com/irontec/ivozprovider/blob/bleeding/doc/dev/en/commits.md)
- [ ] Commits are split per component (schema, web/admin, kamusers, agis, ..)
- [x] Changes have been tested locally
- [ ] Fixes an existing issue (Fixes #XXXX) <!-- Replace XXXX with issue id -->
- [ ] Upport from existing Pull request #XXXX

#### Description
<!-- Describe your changes in detail -->
direction parameters for "rtpengine_manage" are not handle ipv6 to ipv4 interface changes. You should also insert address-family=IP4/IP6 parameter

#### Additional information
<!--
If you have extra information that does not fit previous sections, please add it here.
-->
